### PR TITLE
Program crashes when processing certain maliciously crafted images

### DIFF
--- a/zplgfa.go
+++ b/zplgfa.go
@@ -24,6 +24,12 @@ const (
 // ConvertToZPL is just a wrapper for ConvertToGraphicField which also includes the ZPL
 // starting code ^XA and ending code ^XZ, as well as a Field Separator and Field Origin.
 func ConvertToZPL(img image.Image, graphicType GraphicType) string {
+	//Check before entering the ConvertToGraphicField function
+	//if the width is 0, the function can exit early
+	check := img.Bounds().Size().X / 8
+	if check == 0 {
+		return ""
+	}
 	return fmt.Sprintf("^XA,^FS\n^FO0,0\n%s^FS,^XZ\n", ConvertToGraphicField(img, graphicType))
 }
 


### PR DESCRIPTION
I found that in the `ConvertToGraphicField` function, in the first layer of for loop, if the `width` is 0, the calculation of `line[lineIndex]` will cause the program to go out of bounds. Because the line definition statement is `line := make([]uint8, width)`, the program directly crashes.

```
func ConvertToGraphicField(source image.Image, graphicType GraphicType) string {
	var gfType string
	var lastLine string
	size := source.Bounds().Size()
	width := size.X / 8
	height := size.Y
	if size.Y%8 != 0 {
		width = width + 1
	}

	var GraphicFieldData string

	for y := 0; y < size.Y; y++ {
		line := make([]uint8, width)
		lineIndex := 0
		index := uint8(0)
		currentByte := line[lineIndex]//line[0] is out of bounds
		...
```

The reason why did not choose to introduce error to indicate that the program went wrong is that it seems reasonable to return an empty string, because the image width is 0.